### PR TITLE
Fix Open-Meteo API parameter names and improve data safety

### DIFF
--- a/app/api/weather/route.js
+++ b/app/api/weather/route.js
@@ -186,7 +186,9 @@ async function fetchClimateEstimate(latitude, longitude, raceDate, daysOut) {
   // Most common weather code
   const codeCounts = {};
   for (const c of allCodes) codeCounts[c] = (codeCounts[c] || 0) + 1;
-  const mostCommonCode = Number(Object.entries(codeCounts).sort((a, b) => b[1] - a[1])[0][0]);
+  const mostCommonCode = Object.keys(codeCounts).length > 0
+    ? Number(Object.entries(codeCounts).sort((a, b) => b[1] - a[1])[0][0])
+    : 0;
 
   return {
     type: 'climate',


### PR DESCRIPTION
## Summary
Updates the weather API integration to use the correct Open-Meteo parameter names and adds defensive checks to prevent runtime errors when processing historical weather data.

## Key Changes
- **API Parameter Updates**: Corrected Open-Meteo API field names across forecast and archive endpoints:
  - `windspeed_10m_max` → `wind_speed_10m_max`
  - `weathercode` → `weather_code`
  
- **Data Processing Safety**: Updated data access patterns in `fetchClimateEstimate()` to use optional chaining (`?.`) when accessing array indices, preventing potential undefined reference errors

- **Future Date Validation**: Added check to skip climate estimate ranges where the end date is in the future, since archive data won't exist for those periods

- **Edge Case Handling**: Added null check when calculating the most common weather code to handle cases where no weather codes are available (returns 0 as fallback)

## Implementation Details
The parameter name changes align with Open-Meteo's current API specification. The optional chaining additions provide defensive programming against missing or incomplete data responses. The future date check prevents unnecessary API calls and potential errors when querying the historical archive API.

https://claude.ai/code/session_01R485YNm254qkXWuTBpc5KM