### PR TITLE
Redesign workout cards: cleaner names, centered stats, rounded font

### DIFF
--- a/ios/Coach/Coach/CoachApp.swift
+++ b/ios/Coach/Coach/CoachApp.swift
@@ -26,6 +26,10 @@ struct CoachApp: App {
                     MainTabView()
                         .environment(dataService)
                         .preferredColorScheme(preferredScheme)
+                        // App-wide rounded sans. Explicit `.monospaced` (data,
+                        // dates) and `.serif` (race names, countdowns) fonts pin
+                        // their own design and stay unaffected.
+                        .fontDesign(.rounded)
                 } else if let errorMessage {
                     VStack(spacing: 12) {
                         Text("Sign-in failed")

--- a/ios/Coach/Coach/Models/TrainingPlan.swift
+++ b/ios/Coach/Coach/Models/TrainingPlan.swift
@@ -359,6 +359,65 @@ extension PrescribedSession {
     }
 }
 
+// MARK: - Display title
+
+extension PrescribedSession {
+    /// Athlete-facing workout title with the redundant discipline/type word
+    /// stripped out — the card's colored discipline icon already signals the
+    /// sport, so "Swim — Continuous Effort Block + Drills" reads cleaner as
+    /// "Continuous Effort Block + Drills" and "Strength-Endurance — Upper Body,
+    /// Hip Flexor & Core" as "Upper Body, Hip Flexor & Core". Falls back to the
+    /// raw label if stripping would leave nothing meaningful.
+    var displayTitle: String {
+        Self.stripDisciplineWords(from: label, type: type)
+    }
+
+    /// Type words removed from titles, keyed by session `type`. Multi-word /
+    /// hyphenated entries are listed before their shorter forms so the longest
+    /// match is removed first (e.g. "strength-endurance" before "strength",
+    /// otherwise "Strength-Endurance" would collapse to a dangling "-Endurance").
+    private static func synonyms(for type: String) -> [String] {
+        switch type.lowercased() {
+        case "swim":            return ["swimming", "swim"]
+        case "bike", "cycling": return ["cycling", "bike", "ride", "cycle", "spin"]
+        case "run":             return ["running", "run"]
+        case "strength":        return ["strength-endurance", "strength endurance", "strength", "lifting", "lift"]
+        case "brick":           return ["brick"]
+        default:                return []
+        }
+    }
+
+    static func stripDisciplineWords(from label: String, type: String) -> String {
+        let words = synonyms(for: type)
+        guard !words.isEmpty else { return label }
+
+        var result = label
+        for word in words {
+            let pattern = #"\b"# + NSRegularExpression.escapedPattern(for: word) + #"\b"#
+            result = result.replacingOccurrences(
+                of: pattern,
+                with: "",
+                options: [.regularExpression, .caseInsensitive]
+            )
+        }
+
+        // Collapse the gaps and dangling separators left behind by removal,
+        // e.g. "Easy Aerobic  — Z2 Base" → "Easy Aerobic — Z2 Base", and a
+        // leading " — Continuous…" → "Continuous…".
+        result = result.replacingOccurrences(of: #" {2,}"#, with: " ", options: .regularExpression)
+        result = result.replacingOccurrences(of: #"^[\s—–\-:•,]+"#, with: "", options: .regularExpression)
+        result = result.replacingOccurrences(of: #"[\s—–\-:•,]+$"#, with: "", options: .regularExpression)
+        result = result.trimmingCharacters(in: .whitespaces)
+
+        // Guard against over-stripping: when the type word was the only real
+        // noun ("Long Ride" → "Long", "Z2 Spin" → "Z2"), the remainder is a
+        // meaningless fragment. Keep the original unless at least two
+        // word-characters groups survive.
+        let wordCount = result.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).count
+        return (result.isEmpty || wordCount < 2) ? label : result
+    }
+}
+
 // MARK: - Day Plan
 struct DayPlan: Codable, Identifiable {
     var id: String { day }

--- a/ios/Coach/Coach/Utilities/Theme.swift
+++ b/ios/Coach/Coach/Utilities/Theme.swift
@@ -156,15 +156,18 @@ enum Theme {
     // Mono: SF Mono for data, dates, durations, and system labels.
 
     enum Typography {
-        // Sans — sizes scaled up from the original redesign. Every
-        // surface that wants to grow with the app should route through
-        // these tokens rather than hardcoding `.font(.system(size:))`.
-        static let pageTitle     = Font.system(size: 30, weight: .semibold)
-        static let cardTitle     = Font.system(size: 15, weight: .semibold)
-        static let sessionTitle  = Font.system(size: 20, weight: .semibold)
-        static let body          = Font.system(size: 17, weight: .medium)
-        static let bodyS         = Font.system(size: 15, weight: .medium)
-        static let small         = Font.system(size: 12, weight: .regular)
+        // Sans — SF Pro Rounded (`design: .rounded`) for a softer, friendlier
+        // feel. Sizes scaled up from the original redesign. Every surface that
+        // wants to grow with the app should route through these tokens rather
+        // than hardcoding `.font(.system(size:))`. A global `.fontDesign(.rounded)`
+        // at the app root (see CoachApp) rounds any straggler `.system` text;
+        // mono and serif tokens below pin their own design and are unaffected.
+        static let pageTitle     = Font.system(size: 30, weight: .semibold, design: .rounded)
+        static let cardTitle     = Font.system(size: 15, weight: .semibold, design: .rounded)
+        static let sessionTitle  = Font.system(size: 20, weight: .semibold, design: .rounded)
+        static let body          = Font.system(size: 17, weight: .medium, design: .rounded)
+        static let bodyS         = Font.system(size: 15, weight: .medium, design: .rounded)
+        static let small         = Font.system(size: 12, weight: .regular, design: .rounded)
 
         // Mono
         static func mono(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {

--- a/ios/Coach/Coach/Views/Home/HomeTab.swift
+++ b/ios/Coach/Coach/Views/Home/HomeTab.swift
@@ -518,7 +518,7 @@ struct HomeTab: View {
         SessionCard(
             discipline: disciplineFor(session),
             effort: effortLabel(for: session),
-            name: session.label,
+            name: session.displayTitle,
             stats: statsFor(session),
             status: session.sessionCardStatus,
             trailingAction: AnyView(menu),
@@ -541,6 +541,12 @@ struct HomeTab: View {
     }
 
     private func effortLabel(for session: PrescribedSession) -> String? {
+        // Strength sessions carry effortCategory == .strength, which would
+        // render a "STRENGTH" subtitle under a dumbbell icon and a now
+        // type-free title — triple redundancy. Drop it for strength.
+        if session.type == "strength", session.effortCategory == .strength {
+            return nil
+        }
         if let e = session.effortCategory {
             return e.rawValue
                 .replacingOccurrences(of: "_", with: " ")

--- a/ios/Coach/Coach/Views/Shared/SessionCard.swift
+++ b/ios/Coach/Coach/Views/Shared/SessionCard.swift
@@ -115,6 +115,8 @@ struct SessionCard: View {
                                 .font(Theme.Typography.sessionTitle)
                                 .foregroundStyle(Theme.ink)
                                 .tracking(Theme.Tracking.headline)
+                                .lineLimit(2)
+                                .minimumScaleFactor(0.9)
                                 .fixedSize(horizontal: false, vertical: true)
 
                             if let effort, !effort.isEmpty {
@@ -136,7 +138,7 @@ struct SessionCard: View {
                         HStack(alignment: .top, spacing: 16) {
                             ForEach(stats.prefix(3)) { stat in
                                 statColumn(stat)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .frame(maxWidth: .infinity, alignment: .center)
                             }
                         }
                         .padding(.top, 2)
@@ -182,7 +184,7 @@ struct SessionCard: View {
 
     @ViewBuilder
     private func statColumn(_ stat: Stat) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .center, spacing: 4) {
             Text(stat.label)
                 .font(Theme.Typography.monoLabelS)
                 .foregroundStyle(Theme.ink3)


### PR DESCRIPTION
Updates the workout-card design on the Today and Week tabs.

## Naming
- New `PrescribedSession.displayTitle` strips the redundant discipline word (the colored icon already signals the sport), with an over-strip guard so short titles aren't gutted:
  - *Strength-Endurance — Upper Body, Hip Flexor & Core* → **Upper Body, Hip Flexor & Core**
  - *Swim — Continuous Effort Block + Drills* → **Continuous Effort Block + Drills**
  - *Long Ride* / *Tempo Run* → kept (stripping would leave a fragment)
- Redundant **STRENGTH** subtitle removed from strength cards.
- Titles capped at 2 lines (1 when they fit) with shrink-to-fit.

## Layout
- Stat row (Time / Zone / Distance) now **centers each column** instead of left-aligned edge-to-edge.

## Typography
- App sans switched to **SF Pro Rounded** via `Theme.Typography` tokens + a root `.fontDesign(.rounded)`. Mono (data/dates) and serif (race names, countdown) pin their own design and are unchanged.

This is a display-layer cleanup — existing workouts update immediately; the AI plan-generation prompt is untouched.

Build verified: `xcodebuild ... BUILD SUCCEEDED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)