### PR TITLE
Unify race card across Home and Plan; phase card on Home

### DIFF
--- a/ios/Coach/Coach/Views/Home/HomeTab.swift
+++ b/ios/Coach/Coach/Views/Home/HomeTab.swift
@@ -259,8 +259,8 @@ struct HomeTab: View {
         if let raceName, !raceName.isEmpty,
            let dateStr, !dateStr.isEmpty {
             let (count, unit) = countdownParts(dateStr)
-            let block = RaceBlockView(
-                raceName: raceName,
+            let block = RaceHeroCard(
+                name: raceTypeTitle(name: raceName, location: location),
                 location: location,
                 date: formattedRaceDate(dateStr),
                 count: count,
@@ -290,7 +290,7 @@ struct HomeTab: View {
             NavigationLink {
                 PhaseDetailView(plan: plan, phase: phase)
             } label: {
-                TrainingPhaseBlockView(
+                PhaseHeroCard(
                     phaseDescription: phase.plainLanguageLabel,
                     weeksLeft: plan.weeksLeftInPhase(phase)
                 )

--- a/ios/Coach/Coach/Views/Home/TodayHeaderBlocks.swift
+++ b/ios/Coach/Coach/Views/Home/TodayHeaderBlocks.swift
@@ -13,149 +13,58 @@ private struct PressableBlockStyle: ButtonStyle {
     }
 }
 
-// MARK: - Shared kicker
-//
-// "Training for ›" / "Training phase ›" — accent-colored mono uppercase
-// label with an inline chevron. Used as the kicker on both header blocks.
+// MARK: - Training phase card
 
-private struct BlockKicker: View {
-    let title: String
-
-    var body: some View {
-        HStack(spacing: 5) {
-            Text(title)
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                .textCase(.uppercase)
-                .tracking(0.18 * 9) // 0.18em on 9pt
-                .foregroundStyle(Theme.accent)
-            Image(systemName: "chevron.right")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(Theme.accent)
-        }
-    }
-}
-
-// MARK: - Race block ("Training for")
-
-/// Two-column header pinned to the top of the Today page:
-/// kicker + serif race name + location + mono date on the left,
-/// big serif countdown number + unit on the right. Bottom-aligned so the
-/// number's bottom sits on the date line, with the unit hanging below.
-struct RaceBlockView: View {
-    let raceName: String
-    let location: String?
-    let date: String       // formatted "Sun · Sep 27 · 2026"
-    let count: Int
-    let unit: String       // "Weeks out", "Day out", "Today", etc.
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Last-baseline alignment puts the unit ("Weeks out") on the
-            // same line as the date, with the big number sitting above.
-            // The row's bottom is the shared baseline + descent, so the
-            // hairline ends up tight under the date/unit row.
-            HStack(alignment: .lastTextBaseline, spacing: 16) {
-                VStack(alignment: .leading, spacing: 0) {
-                    BlockKicker(title: "Training for")
-                        .padding(.bottom, 8)
-
-                    Text(raceName)
-                        .font(.system(size: 26, weight: .medium, design: .serif))
-                        .tracking(-0.015 * 26) // -0.015em
-                        .lineSpacing(26 * 0.05) // 1.05 line-height
-                        .foregroundStyle(Theme.ink)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.bottom, 6)
-
-                    if let location, !location.isEmpty {
-                        Text(location)
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundStyle(Theme.ink2)
-                            .lineSpacing(16 * 0.3)
-                            .padding(.bottom, 4)
-                    }
-
-                    Text(date)
-                        .font(.system(size: 11, weight: .regular, design: .monospaced))
-                        .tracking(0.06 * 11)
-                        .foregroundStyle(Theme.ink3)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                // Right column — big number on top, unit beneath. The
-                // VStack's lastTextBaseline is the unit's baseline, so
-                // unit lines up horizontally with the date in the left
-                // column.
-                VStack(alignment: .trailing, spacing: 6) {
-                    Text("\(count)")
-                        .font(.system(size: 64, weight: .regular, design: .serif))
-                        .tracking(-0.04 * 64)
-                        .foregroundStyle(Theme.ink)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.6)
-
-                    Text(unit)
-                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                        .textCase(.uppercase)
-                        .tracking(0.2 * 9)
-                        .foregroundStyle(Theme.ink3)
-                }
-                .fixedSize()
-            }
-            .padding(.top, 4)
-            .padding(.bottom, 14)
-
-            Hairline()
-        }
-        .contentShape(Rectangle())
-    }
-}
-
-// MARK: - Training phase block
-
-/// Compact header block sitting beneath the race block: kicker on top,
-/// then a single line of "Plain phase description · N wks left".
-struct TrainingPhaseBlockView: View {
+/// Card sitting beneath the shared `RaceHeroCard` on the Today page. Mirrors
+/// the race card's container chrome (surface, border, radius) so the two read
+/// as a matched pair: accent kicker, the current phase's plain-language
+/// description, and weeks remaining, with a chevron for the tap-through to
+/// `PhaseDetailView`.
+struct PhaseHeroCard: View {
     let phaseDescription: String
     let weeksLeft: Int   // remaining whole weeks in the phase, 0 = last week
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            BlockKicker(title: "Training phase")
-                .padding(.bottom, 8)
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Training phase")
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .textCase(.uppercase)
+                    .tracking(0.18 * 9)
+                    .foregroundStyle(Theme.accent)
 
-            HStack(spacing: 0) {
                 Text(phaseDescription)
-                    .font(.system(size: 13, weight: .semibold))
-                    .tracking(-0.005 * 13)
+                    .font(.system(size: 17, weight: .semibold))
                     .foregroundStyle(Theme.ink)
-
-                Text(" · ")
-                    .font(.system(size: 13, weight: .regular))
-                    .foregroundStyle(Theme.ink3)
-                    .padding(.horizontal, 6)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Text(weeksLeftText)
-                    .font(.system(size: 11, weight: .regular, design: .monospaced))
-                    .tracking(0.02 * 11)
-                    .foregroundStyle(Theme.ink2)
+                    .font(Theme.Typography.monoMeta)
+                    .foregroundStyle(Theme.ink3)
             }
-            .lineLimit(1)
-            .padding(.top, 0)
 
-            Spacer().frame(height: 14)
+            Spacer(minLength: 8)
 
-            Hairline()
+            Image(systemName: "chevron.right")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Theme.ink3)
         }
-        .padding(.top, 4)
+        .padding(Theme.Spacing.cardP)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.Radius.card)
+                .strokeBorder(Theme.line, lineWidth: 1)
+        )
         .contentShape(Rectangle())
     }
 
     private var weeksLeftText: String {
         switch weeksLeft {
-        case ..<1:  return "last week"
-        case 1:     return "1 wk left"
-        default:    return "\(weeksLeft) wks left"
+        case ..<1:  return "Last week of phase"
+        case 1:     return "1 week left"
+        default:    return "\(weeksLeft) weeks left"
         }
     }
 }
@@ -176,39 +85,17 @@ extension View {
 
 // MARK: - Previews
 
-#Preview("Today header — Light") {
-    ScrollView {
-        VStack(alignment: .leading, spacing: 16) {
-            RaceBlockView(
-                raceName: "IRONMAN 70.3",
-                location: "Cozumel, Mexico",
-                date: "Sun · Sep 27 · 2026",
-                count: 22,
-                unit: "Weeks out"
-            )
-            TrainingPhaseBlockView(
-                phaseDescription: "Building your aerobic base",
-                weeksLeft: 2
-            )
-        }
-        .padding(.horizontal, Theme.Spacing.screenH)
-        .padding(.top, 16)
-    }
-    .background(Theme.bg)
-    .preferredColorScheme(.light)
-}
-
 #Preview("Today header — Dark") {
     ScrollView {
         VStack(alignment: .leading, spacing: 16) {
-            RaceBlockView(
-                raceName: "IRONMAN 70.3",
+            RaceHeroCard(
+                name: "IRONMAN 70.3",
                 location: "Cozumel, Mexico",
                 date: "Sun · Sep 27 · 2026",
-                count: 22,
+                count: 17,
                 unit: "Weeks out"
             )
-            TrainingPhaseBlockView(
+            PhaseHeroCard(
                 phaseDescription: "Building your aerobic base",
                 weeksLeft: 2
             )
@@ -220,32 +107,24 @@ extension View {
     .preferredColorScheme(.dark)
 }
 
-#Preview("Race block — long name & race week") {
-    VStack(alignment: .leading, spacing: 16) {
-        RaceBlockView(
-            raceName: "Boston Marathon Qualifier — Anchorage",
-            location: "Anchorage, Alaska",
-            date: "Sat · Jun 14 · 2026",
-            count: 1,
-            unit: "Day out"
-        )
-        RaceBlockView(
-            raceName: "Race Day",
-            location: nil,
-            date: "Sun · Sep 27 · 2026",
-            count: 0,
-            unit: "Today"
-        )
-        TrainingPhaseBlockView(
-            phaseDescription: "Tapering for race day",
-            weeksLeft: 0
-        )
-        TrainingPhaseBlockView(
-            phaseDescription: "Growing your weekly volume",
-            weeksLeft: 1
-        )
+#Preview("Today header — Light") {
+    ScrollView {
+        VStack(alignment: .leading, spacing: 16) {
+            RaceHeroCard(
+                name: "IRONMAN 70.3",
+                location: "Cozumel, Mexico",
+                date: "Sun · Sep 27 · 2026",
+                count: 17,
+                unit: "Weeks out"
+            )
+            PhaseHeroCard(
+                phaseDescription: "Tapering for race day",
+                weeksLeft: 0
+            )
+        }
+        .padding(.horizontal, Theme.Spacing.screenH)
+        .padding(.top, 16)
     }
-    .padding(.horizontal, Theme.Spacing.screenH)
-    .padding(.top, 16)
     .background(Theme.bg)
+    .preferredColorScheme(.light)
 }

--- a/ios/Coach/Coach/Views/Plan/PlanTab.swift
+++ b/ios/Coach/Coach/Views/Plan/PlanTab.swift
@@ -141,9 +141,10 @@ struct PlanTab: View {
     private func raceHeroBlock(plan: TrainingPlan) -> some View {
         if let name = plan.raceName, !name.isEmpty, let dateStr = plan.raceDate {
             let (count, unit) = countdownParts(dateStr)
+            let location = raceLocation(plan: plan)
             RaceHeroCard(
-                name: name,
-                location: raceLocation(plan: plan),
+                name: raceTypeTitle(name: name, location: location),
+                location: location,
                 date: formatRaceDate(dateStr),
                 count: count,
                 unit: unit
@@ -314,64 +315,6 @@ private func monthDay(_ dateStr: String) -> String? {
     guard let d = inF.date(from: dateStr) else { return nil }
     let outF = DateFormatter(); outF.dateFormat = "MMM d"
     return outF.string(from: d)
-}
-
-// MARK: - Race hero card
-
-/// Containerized race countdown: serif race name + location + date on the
-/// left, big serif countdown number + mono unit on the right.
-private struct RaceHeroCard: View {
-    let name: String
-    let location: String?
-    let date: String
-    let count: Int
-    let unit: String
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 16) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text(name)
-                    .font(Theme.Typography.serifRace)
-                    .foregroundStyle(Theme.ink)
-                    .lineLimit(2)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .minimumScaleFactor(0.8)
-                if let location, !location.isEmpty {
-                    Text(location)
-                        .font(Theme.Typography.body)
-                        .foregroundStyle(Theme.ink2)
-                }
-                Text(date)
-                    .font(Theme.Typography.monoData)
-                    .foregroundStyle(Theme.ink3)
-                    .padding(.top, 2)
-            }
-
-            Spacer(minLength: 12)
-
-            VStack(alignment: .trailing, spacing: 0) {
-                Text("\(count)")
-                    .font(Theme.Typography.serifNumber(72))
-                    .foregroundStyle(Theme.ink)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.6)
-                Text(unit)
-                    .font(Theme.Typography.monoLabelS)
-                    .foregroundStyle(Theme.ink3)
-                    .textCase(.uppercase)
-                    .tracking(Theme.Tracking.monoLabel)
-                    .padding(.top, 2)
-            }
-        }
-        .padding(Theme.Spacing.cardP)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Theme.surface1)
-        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card))
-        .overlay(
-            RoundedRectangle(cornerRadius: Theme.Radius.card)
-                .strokeBorder(Theme.line, lineWidth: 1)
-        )
-    }
 }
 
 // MARK: - Season timeline

--- a/ios/Coach/Coach/Views/Shared/RaceHeroCard.swift
+++ b/ios/Coach/Coach/Views/Shared/RaceHeroCard.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+// MARK: - Race hero card
+
+/// Containerized race countdown — the single race-hero card shared by the
+/// Today and Plan tabs. Race type as the title, location and date beneath it,
+/// and a big serif countdown number + mono unit on the right.
+struct RaceHeroCard: View {
+    /// Race type, e.g. "IRONMAN 70.3" — location is rendered separately below.
+    let name: String
+    let location: String?
+    /// Formatted date line, e.g. "Sun · Sep 27 · 2026".
+    let date: String
+    let count: Int
+    /// Mono uppercase unit, e.g. "Weeks out", "Day out", "Today".
+    let unit: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(name)
+                    .font(Theme.Typography.serifRace)
+                    .foregroundStyle(Theme.ink)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .minimumScaleFactor(0.8)
+                if let location, !location.isEmpty {
+                    Text(location)
+                        .font(Theme.Typography.body)
+                        .foregroundStyle(Theme.ink2)
+                }
+                Text(date)
+                    .font(Theme.Typography.monoData)
+                    .foregroundStyle(Theme.ink3)
+                    .padding(.top, 2)
+            }
+
+            Spacer(minLength: 12)
+
+            VStack(alignment: .trailing, spacing: 0) {
+                Text("\(count)")
+                    .font(Theme.Typography.serifNumber(72))
+                    .foregroundStyle(Theme.ink)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+                Text(unit)
+                    .font(Theme.Typography.monoLabelS)
+                    .foregroundStyle(Theme.ink3)
+                    .textCase(.uppercase)
+                    .tracking(Theme.Tracking.monoLabel)
+                    .padding(.top, 2)
+            }
+        }
+        .padding(Theme.Spacing.cardP)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.Radius.card)
+                .strokeBorder(Theme.line, lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Race type extraction
+
+/// Strips a trailing location/city off a freeform race name so the card title
+/// shows just the race type. Plans store `raceName` as the full event name
+/// (e.g. "IRONMAN 70.3 Cozumel"), while the location lives on the linked event
+/// ("Cozumel, Mexico"), so the city tends to be duplicated at the end of the
+/// name. Falls back to the full name when nothing can be stripped.
+func raceTypeTitle(name: String, location: String?) -> String {
+    let trimmed = name.trimmingCharacters(in: .whitespaces)
+    guard let location, !location.isEmpty else { return trimmed }
+
+    // City = first comma-separated component of the location ("Cozumel" from
+    // "Cozumel, Mexico"). Try the full location first, then the city alone.
+    let city = location.split(separator: ",").first
+        .map { $0.trimmingCharacters(in: .whitespaces) } ?? location
+
+    var result = trimmed
+    for candidate in [location, city] where !candidate.isEmpty {
+        if result.lowercased().hasSuffix(candidate.lowercased()) {
+            result = String(result.dropLast(candidate.count))
+            break
+        }
+    }
+
+    // Trim separators/whitespace left dangling after removal.
+    result = result.replacingOccurrences(of: #"[\s—–\-,:]+$"#, with: "", options: .regularExpression)
+    result = result.trimmingCharacters(in: .whitespaces)
+    return result.isEmpty ? trimmed : result
+}
+
+#Preview("RaceHeroCard") {
+    VStack(spacing: 16) {
+        RaceHeroCard(
+            name: "IRONMAN 70.3",
+            location: "Cozumel, Mexico",
+            date: "Sun · Sep 27 · 2026",
+            count: 17,
+            unit: "Weeks out"
+        )
+        RaceHeroCard(
+            name: "Big Sur Marathon",
+            location: nil,
+            date: "Sat · Jun 14 · 2026",
+            count: 1,
+            unit: "Day out"
+        )
+    }
+    .padding(Theme.Spacing.screenH)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Theme.bg)
+    .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
Makes the race card identical on the Today and Plan tabs, and puts the Home training phase in a matching card.

## Race card
- Extracted `RaceHeroCard` into a shared component (`Views/Shared/RaceHeroCard.swift`) used by both tabs.
- New `raceTypeTitle(name:location:)` strips the duplicated location off the race name so the title is just the race type:
  - "IRONMAN 70.3 Cozumel" + loc "Cozumel, Mexico" → **IRONMAN 70.3**
  - "Big Sur Marathon" → unchanged (city isn't a suffix)
- Both pages: title = race type, location below it, then date, big countdown on the right — in the bordered container.

## Home phase card
- Replaced the flat `TrainingPhaseBlockView` with `PhaseHeroCard` — same container chrome as the race card (surface / border / radius), accent kicker, plain-language phase description, weeks-left, chevron into `PhaseDetailView`.
- Removed the now-unused `RaceBlockView` / `TrainingPhaseBlockView`.

Build verified: `xcodebuild ... BUILD SUCCEEDED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)