### PR TITLE
Use displayTitle on Week Detail session cards

### DIFF
--- a/ios/Coach/Coach/Views/Plan/WeekDetailView.swift
+++ b/ios/Coach/Coach/Views/Plan/WeekDetailView.swift
@@ -276,7 +276,7 @@ private struct WeekDaySessionCard: View {
                             .frame(width: 3)
 
                         VStack(alignment: .leading, spacing: 6) {
-                            Text(session.label)
+                            Text(session.displayTitle)
                                 .font(Theme.Typography.sessionTitle)
                                 .foregroundStyle(Theme.ink)
                                 .tracking(Theme.Tracking.headline)


### PR DESCRIPTION
Applies `session.displayTitle` (type-stripped workout name) to the Week Detail session cards, matching the Today tab. This one line was inadvertently left out of PR #88 (workout-card redesign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)